### PR TITLE
Fix logOut frontend functionality

### DIFF
--- a/services/frontend/src/components/NavBar.vue
+++ b/services/frontend/src/components/NavBar.vue
@@ -49,6 +49,7 @@ export default {
   methods: {
     async logout () {
       await this.$store.dispatch('logOut');
+      await this.$store.commit('isLoggedIn', false);
       this.$router.push('/login');
     }
   },


### PR DESCRIPTION
Without change state `isLoggedIn=false` we can see and have access to all NavBar options (like Dashboard, Profile). This patch disable access to Dashboard and Profile after click logOut on frontend.